### PR TITLE
Yocto started to ask for `LAYERSERIES_COMPAT_x` to be explicitly set …

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,6 +4,8 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
+LAYERSERIES_COMPAT_rtlwifi = "sumo"
+
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"
 BBFILE_PATTERN_rtlwifi = "${LAYERDIR}"


### PR DESCRIPTION
…in 3rd-party layers for compatibility assurance. This PR fixes the following warning by setting `LAYERSERIES_COMPAT_rtlwifi` to `sumo` in the master branch.

     WARNING: Layer rtlwifi should set LAYERSERIES_COMPAT_rtlwifi in its conf/layer.conf file to list the core layer names it is compatible with.

Related commit on Poky: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=a0f22fd9712aa724f4e1e9a3ba4a2a9d6ce52403

Signed-off-by: wouterlucas <wouter@wouterlucas.com>