### PR TITLE
layer.conf: add "rocko" to LAYERSERIES_COMPAT_rtlwifi

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "sumo"
+LAYERSERIES_COMPAT_rtlwifi = "rocko sumo"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"


### PR DESCRIPTION
LAYERSERIES_COMPAT is checked from rocko onwards, so setting to
"sumo" prevents meta-rtlwifi from being combined with rocko.

Add "rocko" to LAYERSERIES_COMPAT_rtlwifi since the master branch of
meta-rtlwifi is usable with both rocko and sumo branches of oe-core.
