### PR TITLE
Add gatesgarth to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "rocko sumo thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_rtlwifi = "rocko sumo thud warrior zeus dunfell gatesgarth"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"


### PR DESCRIPTION
The master branch of openembedded-core now only lists `gatesgarth` in `LAYERSERIES_CORENAMES` after https://git.openembedded.org/openembedded-core/commit/?id=d2e0d82f3e34a6c49066e39775572c5b8cd3c392.