### PR TITLE
Add hardknott to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "zeus dunfell gatesgarth"
+LAYERSERIES_COMPAT_rtlwifi = "zeus dunfell gatesgarth hardknott"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"


### PR DESCRIPTION
This change is needed to build against the current openembedded-core master branch and the upcoming Yocto Project 3.3 "hardknott" release.