### PR TITLE
fix:(8812au) #21 enforce deploying kernel moduld to image

### DIFF
--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -15,3 +15,13 @@ SRCREV = "30d47a0a3f43ccb19e8fd59fe93d74a955147bf2"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE_append = " KSRC=${STAGING_KERNEL_DIR}"
+
+MODULES_INSTALL_TARGET="install"
+
+do_install () {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless
+    install -m 0644 ${B}/8812au.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/rtl8812au.ko
+}
+
+FILES_${PN} += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/rtl8812au.ko"
+RPROVIDES_${PN} += "kernel-module-${PN}-${KERNEL_VERSION}"


### PR DESCRIPTION
Although the recipe has been included in the image definition,
only the license files are deployed but the kernel module
is missing when building for Yocto 3.1 Dunfell.

The extra lines in the recipe enforces the deployment
of the kernel module.
