### PR TITLE
Convert to new override syntax & depend on rtl8723 firmware

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "zeus dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_rtlwifi = "dunfell gatesgarth hardknott"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_rtlwifi = "dunfell gatesgarth hardknott honister"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"

--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -31,5 +31,5 @@ do_install () {
     echo "blacklist rtl8xxxu" > ${D}${sysconfdir}/modprobe.d/rtl8723-blacklist.conf
 }
 
-FILES_${PN} += "${sysconfdir}"
-RDEPENDS_${PN} += "linux-firmware-rtl8723"
+FILES:${PN} += "${sysconfdir}"
+RDEPENDS:${PN} += "linux-firmware-rtl8723"

--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -32,3 +32,4 @@ do_install () {
 }
 
 FILES_${PN} += "${sysconfdir}"
+RDEPENDS_${PN} += "linux-firmware-rtl8723"

--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=4b85004ff83dd932ff28f7f348fb2a28"
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 inherit module
 
@@ -14,4 +14,4 @@ SRCREV = "30d47a0a3f43ccb19e8fd59fe93d74a955147bf2"
 
 S = "${WORKDIR}/git"
 
-EXTRA_OEMAKE_append = " KSRC=${STAGING_KERNEL_DIR}"
+EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"

--- a/recipes-bsp/drivers/rtl8821cu.bb
+++ b/recipes-bsp/drivers/rtl8821cu.bb
@@ -24,6 +24,6 @@ do_install () {
     install -m 0644 ${B}/8821cu.ko ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/rtl8821cu.ko
 }
 
-FILES_${PN} += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/rtl8821cu.ko"
-RPROVIDES_${PN} += "kernel-module-${PN}-${KERNEL_VERSION}"
+FILES:${PN} += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/rtl8821cu.ko"
+RPROVIDES:${PN} += "kernel-module-${PN}-${KERNEL_VERSION}"
 


### PR DESCRIPTION
* Convert the layer to the new override syntax required to build with the master branch of bitbake, openembedded-core & poky. This breaks compatibility with zeus but compatibility with dunfell and later releases should be maintained as patches have been backported to the relevant bitbake branches to support the new syntax. We also need to mark the layer as compatible with the upcoming honister release for the build to succeed.

* Make rtl8723bu depend on the rtl8723 firmware so users of this layer don't need to remember to add the firmware to their image dependencies.