### PR TITLE
Backport rtl8723bu updates to dunfell branch

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -32,3 +32,4 @@ do_install () {
 }
 
 FILES_${PN} += "${sysconfdir}"
+RDEPENDS_${PN} += "linux-firmware-rtl8723"

--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 
 PV = "1.0-git"
-SRCREV = "c9549d172a4f9d6ccf6d528682640246a41c2f0c"
+SRCREV = "ce4490b1e0dcedec30659dc20b945b90d9c3d83c"
 SRC_URI = "git://github.com/lwfinger/rtl8723bu.git;protocol=https \
            file://0002-realtek-Disable-IPS-mode.patch "
 

--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 
 PV = "1.0-git"
-SRCREV = "a8bd4b6c0481479408e67ac2e1c6fd5dc499e37f"
+SRCREV = "c9549d172a4f9d6ccf6d528682640246a41c2f0c"
 SRC_URI = "git://github.com/lwfinger/rtl8723bu.git;protocol=https \
            file://0002-realtek-Disable-IPS-mode.patch "
 


### PR DESCRIPTION
Our meta-sancloud layer now uses a 5.10 kernel on the dunfell branch. This requires some additional commits to be backported to the dunfell branch of meta-rtlwifi in order to successfully build the rtl8723bu driver.