### PR TITLE
Add rtl8821au driver recipe

### DIFF
--- a/recipes-bsp/drivers/rtl8821au.bb
+++ b/recipes-bsp/drivers/rtl8821au.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Linux driver for RTL8811AU and RTL8821AU chipsets"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://Kconfig;md5=bfbce45993b47a1618e0b3f8f4224918"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+inherit module
+
+SRC_URI = " \
+	git://github.com/morrownr/8821au-20210708.git;protocol=https;branch=main \
+	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+"
+
+SRCREV = "a133274b0532c17318e8790b771566f4a6b12b7c"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"

--- a/recipes-bsp/drivers/rtl8821au/0001-Use-modules_install-as-wanted-by-yocto.patch
+++ b/recipes-bsp/drivers/rtl8821au/0001-Use-modules_install-as-wanted-by-yocto.patch
@@ -1,0 +1,28 @@
+From 30836d3579b3536ce174082f451acf7fea638a8d Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Mon, 1 Aug 2016 23:51:45 +0200
+Subject: [PATCH] Use modules_install as wanted by yocto
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+---
+ Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 70c609a..b5ecf55 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1051,6 +1051,9 @@ all: modules
+ modules:
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+ 
++modules_install:
++	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules_install
++
+ strip:
+ 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded
+ 
+-- 
+2.1.4


### PR DESCRIPTION
Add support for rtl8821au chipset by adding a driver recipe. Mostly copied over from rtl8812au recipe with changed source location and license checksum.

Tested with the following setup:
- Raspberry Pi 2
- Linux 5.15.92
- TP-Link Archer T2U

Built on Poky hash d42904ba0cf0eac28ef79b0e6015150d376d134d