### PR TITLE
feat(8723du): add driver RTL8723DU v5.13.4

### DIFF
--- a/recipes-bsp/drivers/rtl8723du.bb
+++ b/recipes-bsp/drivers/rtl8723du.bb
@@ -1,0 +1,16 @@
+SUMMARY = "RTL88x2BU kernel driver (wifi)"
+DESCRIPTION = "RTL88x2BU kernel driver (like RTL8812BU)"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRCREV = "efcaffbd60e8114b5338f51cec8b3f7b6ef51045"
+SRC_URI = "\
+    git://github.com/lwfinger/rtl8723du;protocol=https;branch=master \
+    file://0001-use-modules_install-as-wanted-by-yocto.patch \
+"
+PV = "5.13.4-git"
+
+inherit module
+S = "${WORKDIR}/git"
+EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"

--- a/recipes-bsp/drivers/rtl8723du/0001-use-modules_install-as-wanted-by-yocto.patch
+++ b/recipes-bsp/drivers/rtl8723du/0001-use-modules_install-as-wanted-by-yocto.patch
@@ -1,0 +1,28 @@
+From 30836d3579b3536ce174082f451acf7fea638a8d Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Mon, 1 Aug 2016 23:51:45 +0200
+Subject: [PATCH] Use modules_install as wanted by yocto
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+---
+ Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 70c609a..b5ecf55 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1051,6 +1051,9 @@ all: modules
+ modules:
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+ 
++modules_install:
++	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules_install
++
+ strip:
+ 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded
+ 
+-- 
+2.1.4


### PR DESCRIPTION
Although there is a driver for RTL8723DU in newer kernels (>=6.2), this kernel is not available with current Yocto releases. Hence, it is useful to have a driver for this chipset at hand for current kernels.

see: https://wireless.wiki.kernel.org/en/users/drivers/rtl819x
