### PR TITLE
fix(8812au): upgrade driver RTL8812au to v5.13.6

### DIFF
--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -1,17 +1,18 @@
 SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://Kconfig;md5=4b85004ff83dd932ff28f7f348fb2a28"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 inherit module
 
 SRC_URI = " \
-	git://github.com/gordboy/rtl8812au.git;protocol=https;branch=master \
-	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+    git://github.com/morrownr/8812au-20210629;protocol=https;branch=master \
+    file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 "
 
-SRCREV = "30d47a0a3f43ccb19e8fd59fe93d74a955147bf2"
+SRCREV = "663dc8fe1fbc100be9ed532f003c6eb90dab3d33"
 
+PV = "5.13.6-git"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
The previous repository is archived and thus development halted. The new repository provides a newer version v5.13.6.
 It compiles well on Yocto Kirkstone.