### PR TITLE
feat(88x2bu): add driver RTL8812BU/RTL8822BU v5.13.1

### DIFF
--- a/recipes-bsp/drivers/rtl88x2bu.bb
+++ b/recipes-bsp/drivers/rtl88x2bu.bb
@@ -1,0 +1,12 @@
+SUMMARY = "RTL88x2BU kernel driver (wifi)"
+DESCRIPTION = "RTL88x2BU kernel driver (like RTL8812BU)"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
+
+SRCREV = "9a04d2bb9d882c7f2708560774d7b96a70d83f4b"
+SRC_URI = "git://github.com/morrownr/88x2bu-20210702;protocol=https;branch=master"
+PV = "5.13.1-git"
+
+inherit module
+S = "${WORKDIR}/git"
+EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"


### PR DESCRIPTION
Although there is a driver for RTL8822BU in newer kernels (>=6.2), this kernel is not available with current Yocto releases. This kernel version has not been released yet, either. Hence, it is useful to have a driver for this chipset at hand for currently used kernels.

The Linux driver pages does not state whether RTL8812BU is supported or not. So, maybe this driver is good to have for these chipsets too.

see: https://wireless.wiki.kernel.org/en/users/drivers/rtl819x