### PR TITLE
layer.conf: Update layer series compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Append recipe dir to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_rtlwifi = "dunfell gatesgarth hardknott honister kirkstone"
+LAYERSERIES_COMPAT_rtlwifi = "dunfell kirkstone mickledore"
 
 BBFILE_COLLECTIONS += "rtlwifi"
 BBFILE_PRIORITY_rtlwifi = "1"


### PR DESCRIPTION
As of 2023-06-08, the currently supported layers are Dunfell, Kirkstone & Mickledore (see https://wiki.yoctoproject.org/wiki/Releases).