### PR TITLE
Fixed problem with Yocto 4.0 (Kirikstone) causing bitbake failure.

### DIFF
--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -1,16 +1,17 @@
 SUMMARY = "Realtek 802.11n WLAN Adapter Linux driver"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 inherit module
 
 SRC_URI = " \
-    git://github.com/morrownr/8812au-20210629;protocol=https;branch=master \
+    git://github.com/morrownr/8812au-20210629.git;protocol=https;branch=main \
     file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 "
 
-SRCREV = "663dc8fe1fbc100be9ed532f003c6eb90dab3d33"
+#SRCREV = "663dc8fe1fbc100be9ed532f003c6eb90dab3d33"
+SRCREV = "b5f4e6e894eca8fea38661e2fc22a2570e0274ad"
 
 PV = "5.13.6-git"
 S = "${WORKDIR}/git"

--- a/recipes-bsp/drivers/rtl8814au.bb
+++ b/recipes-bsp/drivers/rtl8814au.bb
@@ -4,10 +4,9 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
 SRCREV = "6f80699e68fd2a9f2bba3f1a56ca06d1b7992bd8"
-SRC_URI = " \
-    git://github.com/morrownr/8814au;protocol=https;branch=main \
-    file://0001-fix-makefile.patch \
-"
+SRC_URI = "git://github.com/morrownr/8814au;protocol=https;branch=main \
+           file://0001-Add-make-target-modules_install.patch \
+           "
 PV = "5.8.5.1-git"
 
 inherit module

--- a/recipes-bsp/drivers/rtl8814au.bb
+++ b/recipes-bsp/drivers/rtl8814au.bb
@@ -1,10 +1,13 @@
 SUMMARY = "RTL8814AU kernel driver (wifi)"
 DESCRIPTION = "RTL8814ABU kernel driver"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
 SRCREV = "6f80699e68fd2a9f2bba3f1a56ca06d1b7992bd8"
-SRC_URI = "git://github.com/morrownr/8814au;protocol=https;branch=master"
+SRC_URI = " \
+    git://github.com/morrownr/8814au;protocol=https;branch=main \
+    file://0001-fix-makefile.patch \
+"
 PV = "5.8.5.1-git"
 
 inherit module

--- a/recipes-bsp/drivers/rtl8814au/0001-Add-make-target-modules_install.patch
+++ b/recipes-bsp/drivers/rtl8814au/0001-Add-make-target-modules_install.patch
@@ -1,3 +1,12 @@
+From e29aadaa5dddbf53965f364d16846cf51b42d0fc Mon Sep 17 00:00:00 2001
+From: Yutaka KOBAYASHI <kobayuta@gmail.com>
+Date: Wed, 2 Aug 2023 19:56:01 +0900
+Subject: [PATCH] Add make target(modules_install)
+
+---
+ Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
 diff --git a/Makefile b/Makefile
 index f32615e..5f85324 100644
 --- a/Makefile

--- a/recipes-bsp/drivers/rtl8814au/0001-fix-makefile.patch
+++ b/recipes-bsp/drivers/rtl8814au/0001-fix-makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index f32615e..5f85324 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2392,6 +2392,9 @@ all: modules
+ modules:
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+ 
++modules_install:
++	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules_install
++
+ strip:
+ 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded
+ 

--- a/recipes-bsp/drivers/rtl8821au.bb
+++ b/recipes-bsp/drivers/rtl8821au.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Linux driver for RTL8811AU and RTL8821AU chipsets"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 inherit module

--- a/recipes-bsp/drivers/rtl88x2bu.bb
+++ b/recipes-bsp/drivers/rtl88x2bu.bb
@@ -4,7 +4,10 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ca671256c791bbbf7c985ca88dc89fc9"
 
 SRCREV = "9a04d2bb9d882c7f2708560774d7b96a70d83f4b"
-SRC_URI = "git://github.com/morrownr/88x2bu-20210702;protocol=https;branch=master"
+SRC_URI = " \
+	git://github.com/morrownr/88x2bu-20210702;protocol=https;branch=main \
+	file://0001-fix-makefile.patch \
+"
 PV = "5.13.1-git"
 
 inherit module

--- a/recipes-bsp/drivers/rtl88x2bu/0001-fix-makefile.patch
+++ b/recipes-bsp/drivers/rtl88x2bu/0001-fix-makefile.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 1cd1c6a..af7bd00 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2502,6 +2502,9 @@ all: modules
+ modules:
+ 	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd)  modules
+ 
++modules_install:
++	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd) modules_install
++
+ strip:
+ 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded
+ 


### PR DESCRIPTION
The following points have been corrected.

- Change github branch designation from master to main.
- Fix MD5 values in LICENSE file.
- Added missing target (modules_install) in Makefile.

I have confirmed that bitbake completes successfully with Yocto4.0 (Krikstone).
