### PR TITLE
rtl8723bu: fix QA warn [buildpaths]

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -17,8 +17,10 @@ inherit module
 
 EXTRA_OEMAKE  = "ARCH=${ARCH} \
                  KSRC=${STAGING_KERNEL_BUILDDIR} \
-                 USER_EXTRA_CFLAGS='-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT' \
-                "
+                 USER_EXTRA_CFLAGS='-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT \
+                 -fdebug-prefix-map=${WORKDIR}=. -fdebug-prefix-map=${TMPDIR}=. \
+                 -fmacro-prefix-map=${WORKDIR}=. -fmacro-prefix-map=${TMPDIR}=. \
+'"
 
 do_compile () {
     oe_runmake


### PR DESCRIPTION
```
    rtl8723bu: fix QA warn [buildpaths]

    This driver uses __FILES__ macro in the source code which puts the build
    machine paths into the binary. Strip them away using a gcc option. Fixes
    this type of error:

    WARNING: rtl8723bu-4.3.6.11-git-r0 do_package_qa: QA Issue: File
    /usr/lib/modules/6.12.24-ti-g8ac18028b665/8723bu.ko
    in package rtl8723bu contains reference to TMPDIR [buildpaths]
```