### PR TITLE
Per-kernel driver fixes round 2: walnascar (kernel 6.12) green

### DIFF
--- a/recipes-bsp/drivers/rtl8192eu.bb
+++ b/recipes-bsp/drivers/rtl8192eu.bb
@@ -4,11 +4,11 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRC_URI = "git://github.com/Mange/rtl8192eu-linux-driver.git;protocol=https;branch=realtek-4.4.x"
-SRCREV = "528ae31705764d78cc117abd604d9b799bd52543"
+SRCREV = "9c0511420da11214c68d8591b19459ba10892aab"
 
 S = "${WORKDIR}/git"
 
-PV = "4.4.1-git"
+PV = "4.4.1-git+2026.03"
 
 DEPENDS = "virtual/kernel"
 

--- a/recipes-bsp/drivers/rtl8723du.bb
+++ b/recipes-bsp/drivers/rtl8723du.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171d
 # Yocto-specific Makefile glue (modules_install target) and per-kernel
 # compile fixes on top of lwfinger's last upstream commit.
 SRC_URI = "git://github.com/EmbeddedAndroid/rtl8723du;protocol=https;branch=embeddedandroid"
-SRCREV = "5bd46faeedae647bca25e1a6a8d4de9bcf963899"
+SRCREV = "83743042b778ac0b07b068a8e870ecc97d35ec4f"
 PV = "5.13.4-git+2026.05"
 
 DEPENDS = "virtual/kernel"

--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -10,9 +10,12 @@ SRC_URI = " \
     file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 "
 
-SRCREV = "c0efee9cd121d9f0c815d9771475f76339a8f7d3"
+# 9704072d is the last good commit before upstream PR #62 (Apr 2026)
+# introduced the same undefined _FW_UNDER_SURVEY reference seen in
+# rtl8821au's PR #198. Includes upstream's kernel 6.13 / 6.14 fixes.
+SRCREV = "9704072df4d75cedf8d622cf2a483aef05109e41"
 
-PV = "5.13.6-git"
+PV = "5.13.6-git+2025.09"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"

--- a/recipes-bsp/drivers/rtl8814au.bb
+++ b/recipes-bsp/drivers/rtl8814au.bb
@@ -3,11 +3,11 @@ DESCRIPTION = "RTL8814ABU kernel driver"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
-SRCREV = "6f80699e68fd2a9f2bba3f1a56ca06d1b7992bd8"
+SRCREV = "b1866ce2b857a8dfe2e147e19eb8eca0a842ce18"
 SRC_URI = "git://github.com/morrownr/8814au;protocol=https;branch=main \
            file://0001-Add-make-target-modules_install.patch \
            "
-PV = "5.8.5.1-git"
+PV = "5.8.5.1-git+2026.02"
 
 inherit module
 S = "${WORKDIR}/git"

--- a/recipes-bsp/drivers/rtl8821cu.bb
+++ b/recipes-bsp/drivers/rtl8821cu.bb
@@ -4,12 +4,12 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-SRCREV = "96c65c58b544241178638e810b333dcc9aa26b91"
+SRCREV = "7f63a9da2e8ed83403f6f920e9b1628a37b38ef4"
 SRC_URI = " \
     git://github.com/morrownr/8821cu-20210916;protocol=https;branch=main \
     file://0001-use-modules_install-as-wanted-by-yocto.patch \
 "
-PV = "5.12.0.4-git"
+PV = "5.12.0.4-git+2025.12"
 
 inherit module
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Second pass of per-kernel-version maintenance work. Gets every driver compiling on both LTS kernels we care about today: 6.6 (scarthgap) and 6.12 (walnascar). Kernel 6.14 still has three holdouts (rtl8723bu, rtl8723du, rtl8814au) which are tracked separately.

Verified via a native (driver, kernel) compile matrix run on a Debian trixie container against linux 6.6.93, 6.12.30 and 6.14.4. After this PR the 6.6 and 6.12 columns are all OK.

rtl8192eu: bumped SRCREV from 528ae317 (2019) to upstream HEAD 9c051142 (Mar 2026). Old revision broke on kernel 6.12 because struct usb_driver.drvwrap was removed in 6.8 and cfg80211_ch_switch_notify gained then lost an argument. Mange's HEAD has tracked both.

rtl8814au: bumped SRCREV from 6f80699e (Aug 2023) to b1866ce2 (Feb 2026). Upstream rolled in kernel 6.12 fixes; old SRCREV was failing on 6.12.

rtl8821cu: bumped SRCREV from 96c65c58 to 7f63a9da (Dec 2025) to pick up the kernel 6.14 get_antenna callback signature change.

rtl8812au: bumped SRCREV from c0efee9c to 9704072d (Sep 2025), the last good commit before upstream PR #62 introduced an undefined _FW_UNDER_SURVEY reference (the same regression that hit rtl8821au via PR #198). Includes upstream's kernel 6.13 + 6.14 support.

rtl8723du: bumped the EmbeddedAndroid/rtl8723du fork SRCREV to absorb two new fork commits:
  - usb_intf: fix shutdown callback for kernel 6.8+ (drvwrap removed; usb_driver.shutdown now takes struct usb_interface * directly)
  - ioctl_cfg80211: drop punct_bitmap arg on kernel 6.9+ (the extra arg added in 6.3 was reverted in 6.9)

Native compile matrix at the SRCREVs in this PR:

| Driver     | 6.6  | 6.12 | 6.14 |
|------------|------|------|------|
| rtl8192eu  | OK   | OK   | OK   |
| rtl8723bu  | OK   | OK   | FAIL |
| rtl8723du  | OK   | OK   | FAIL |
| rtl8812au  | OK   | OK   | OK   |
| rtl8814au  | OK   | OK   | FAIL |
| rtl8821au  | OK   | OK   | OK   |
| rtl8821cu  | OK   | OK   | OK   |
| rtl88x2bu  | OK   | OK   | OK   |

Remaining 6.14 failures are cfg80211 callback signature changes that will be addressed in a follow-up: rtl8821cu-style get_antenna add for the others, plus set_monitor_channel for rtl8723du, plus rtl8723bu and rtl8814au will need their own forks (lwfinger upstream is stale, morrownr/8814au has its own issue at 6.14).