### PR TITLE
Per-kernel driver fixes round 3: kernel 6.14 green for all 8 drivers

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -3,10 +3,14 @@ DESCRIPTION = "RTL8723 kernel driver"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 
+# Track a maintained fork of the lwfinger/rtl8723bu driver under
+# github.com/EmbeddedAndroid. The 'embeddedandroid' branch starts
+# from lwfinger HEAD and adds per-kernel compile fixes that the
+# upstream maintainer hasn't picked up.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-PV = "4.3.6.11-git"
-SRCREV = "af3a408d6399655b0db23c2c8720436ca725ca47"
-SRC_URI = "git://github.com/lwfinger/rtl8723bu.git;protocol=https;branch=master \
+PV = "4.3.6.11-git+2026.05"
+SRCREV = "1c03fb14f015482054b5be4efc6d3e39f7f1c944"
+SRC_URI = "git://github.com/EmbeddedAndroid/rtl8723bu.git;protocol=https;branch=embeddedandroid \
            file://0002-realtek-Disable-IPS-mode.patch "
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/drivers/rtl8723du.bb
+++ b/recipes-bsp/drivers/rtl8723du.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171d
 # Yocto-specific Makefile glue (modules_install target) and per-kernel
 # compile fixes on top of lwfinger's last upstream commit.
 SRC_URI = "git://github.com/EmbeddedAndroid/rtl8723du;protocol=https;branch=embeddedandroid"
-SRCREV = "83743042b778ac0b07b068a8e870ecc97d35ec4f"
+SRCREV = "750035cadf4de2a1c12fab74f81d757fbfda7598"
 PV = "5.13.4-git+2026.05"
 
 DEPENDS = "virtual/kernel"

--- a/recipes-bsp/drivers/rtl8814au.bb
+++ b/recipes-bsp/drivers/rtl8814au.bb
@@ -3,11 +3,15 @@ DESCRIPTION = "RTL8814ABU kernel driver"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
-SRCREV = "b1866ce2b857a8dfe2e147e19eb8eca0a842ce18"
-SRC_URI = "git://github.com/morrownr/8814au;protocol=https;branch=main \
+# Track a maintained fork of morrownr/8814au under
+# github.com/EmbeddedAndroid. The 'embeddedandroid' branch carries
+# fixes for kernel-version guards where upstream gated newer
+# cfg80211_ops fields on the wrong KERNEL_VERSION.
+SRCREV = "7fc42c645546f5ff13e9fe9ef6d4ec2fa73c998f"
+SRC_URI = "git://github.com/EmbeddedAndroid/8814au;protocol=https;branch=embeddedandroid \
            file://0001-Add-make-target-modules_install.patch \
            "
-PV = "5.8.5.1-git+2026.02"
+PV = "5.8.5.1-git+2026.05"
 
 inherit module
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Third pass of per-kernel-version maintenance. With this PR the (driver, kernel) compile matrix is fully green across rtl8192eu / rtl8723bu / rtl8723du / rtl8812au / rtl8814au / rtl8821au / rtl8821cu / rtl88x2bu against kernels 6.6, 6.12 and 6.14.

rtl8723du: bumped the EmbeddedAndroid/rtl8723du fork SRCREV to absorb two more cfg80211_ops signature changes:
  - set_monitor_channel gained struct net_device *dev in kernel 6.13
  - get_tx_power gained unsigned int link_id in kernel 6.14

rtl8723bu: switched from lwfinger/rtl8723bu to a new EmbeddedAndroid/rtl8723bu fork. lwfinger's HEAD == the recipe's existing SRCREV (no upstream activity), so the kernel 6.14 get_tx_power signature change had nowhere to land upstream. Fork carries the same link_id guard as rtl8723du.

rtl8814au: switched from morrownr/8814au to a new EmbeddedAndroid/8814au fork. Upstream had already added kernel guards for radio_idx in set_wiphy_params / set_tx_power / get_tx_power, but gated them on LINUX_VERSION_CODE >= 6.14 — radio_idx didn't actually land until kernel 6.17, so the build broke on 6.14, 6.15, 6.16. Fork splits the guards: link_id at 6.14+, radio_idx at 6.17+.

Native (driver, kernel) compile matrix at this PR's SRCREVs:

| Driver     | 6.6  | 6.12 | 6.14 |
|------------|------|------|------|
| rtl8192eu  | OK   | OK   | OK   |
| rtl8723bu  | OK   | OK   | OK   |
| rtl8723du  | OK   | OK   | OK   |
| rtl8812au  | OK   | OK   | OK   |
| rtl8814au  | OK   | OK   | OK   |
| rtl8821au  | OK   | OK   | OK   |
| rtl8821cu  | OK   | OK   | OK   |
| rtl88x2bu  | OK   | OK   | OK   |

Three EmbeddedAndroid driver forks now exist alongside the existing rtl8723du fork: rtl8723bu, 8814au. All three carry their per-kernel fixes on an 'embeddedandroid' branch that starts from the respective upstream HEAD.