### PR TITLE
ci: extend master to whinlatter and wrynose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,83 @@ jobs:
             rtl8192eu rtl8723bu rtl8723du rtl8812au rtl8814au \
             rtl8821au rtl8821cu rtl88x2bu
 
+  parse-oe-core:
+    # Whinlatter and wrynose dropped the combined poky repository, so
+    # to test them we have to clone openembedded-core + bitbake
+    # separately. Kept as a separate job from `parse` so the existing
+    # poky-based path stays untouched.
+    name: parse (${{ matrix.release }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [whinlatter, wrynose]
+    steps:
+      - name: Checkout meta-rtlwifi
+        uses: actions/checkout@v4
+        with:
+          path: meta-rtlwifi
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+                      "$AGENT_TOOLSDIRECTORY"
+
+      - name: Clone oe-core (${{ matrix.release }})
+        run: |
+          git clone --depth 1 --branch ${{ matrix.release }} \
+            https://git.openembedded.org/openembedded-core oe-core
+
+      - name: Clone bitbake (${{ matrix.release }})
+        run: |
+          git clone --depth 1 --branch ${{ matrix.release }} \
+            https://git.openembedded.org/bitbake oe-core/bitbake
+
+      - name: Install Yocto host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gawk wget git diffstat unzip texinfo gcc build-essential chrpath \
+            socat cpio python3 python3-pip python3-pexpect xz-utils debianutils \
+            iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool \
+            file locales libacl1
+          sudo locale-gen en_US.UTF-8
+
+      - name: Parse the layer
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+        run: |
+          set -eo pipefail
+          cd oe-core
+          # oe-core ships oe-init-build-env at its top level; sourcing
+          # it without poky's meta-yocto* layers means we only have
+          # meta-core, which is what we want for layer-parse smoke.
+          source oe-init-build-env build
+          cat >> conf/local.conf <<'EOF'
+          MACHINE = "qemux86-64"
+          BB_NUMBER_THREADS = "2"
+          PARALLEL_MAKE = "-j 2"
+          INHERIT += "rm_work"
+          CONF_VERSION = "2"
+          EOF
+          bitbake-layers add-layer "$GITHUB_WORKSPACE/meta-rtlwifi"
+          bitbake-layers show-layers
+          bitbake -p
+
+      - name: Fetch all recipes
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+        run: |
+          set -eo pipefail
+          cd oe-core
+          source oe-init-build-env build
+          bitbake -c fetch -k \
+            rtl8192eu rtl8723bu rtl8723du rtl8812au rtl8814au \
+            rtl8821au rtl8821cu rtl88x2bu
+
   # yocto-check-layer is intentionally not run here:
   #
   # The scarthgap/styhead/walnascar copies of checklayer decorate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [whinlatter, wrynose]
+        include:
+          # bitbake versions itself independently of Yocto release
+          # names, so each entry maps the oe-core branch to the
+          # bitbake-the-tool branch that release expects.
+          - release: whinlatter
+            bitbake: '2.16'
+          - release: wrynose
+            bitbake: '2.18'
     steps:
       - name: Checkout meta-rtlwifi
         uses: actions/checkout@v4
@@ -122,9 +129,9 @@ jobs:
           git clone --depth 1 --branch ${{ matrix.release }} \
             https://git.openembedded.org/openembedded-core oe-core
 
-      - name: Clone bitbake (${{ matrix.release }})
+      - name: Clone bitbake (${{ matrix.bitbake }})
         run: |
-          git clone --depth 1 --branch ${{ matrix.release }} \
+          git clone --depth 1 --branch ${{ matrix.bitbake }} \
             https://git.openembedded.org/bitbake oe-core/bitbake
 
       - name: Install Yocto host dependencies

--- a/.github/workflows/nightly-compile-matrix.yml
+++ b/.github/workflows/nightly-compile-matrix.yml
@@ -10,7 +10,7 @@ on:
       kernels:
         description: 'Space-separated kernel versions to test'
         required: false
-        default: '6.6.93 6.12.30 6.14.4'
+        default: '6.6.93 6.12.30 6.14.4 6.16.12 6.18.29'
 
 # Don't pile up nightly runs if one is already in progress.
 concurrency:
@@ -24,7 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kernel: ['6.6.93', '6.12.30', '6.14.4']
+        # Kernels covered:
+        #   6.6  - scarthgap LTS
+        #   6.12 - walnascar
+        #   6.14 - mid-stable, exercises the cfg80211 punct_bitmap revert
+        #   6.16 - whinlatter
+        #   6.18 - wrynose LTS
+        kernel: ['6.6.93', '6.12.30', '6.14.4', '6.16.12', '6.18.29']
         driver:
           - rtl8192eu
           - rtl8723bu


### PR DESCRIPTION
Adds CI coverage for the two Yocto releases that dropped the combined poky repository: whinlatter (5.3) and wrynose (6.0 LTS).

ci.yml grows a parse-oe-core job alongside the existing poky-based parse. It clones openembedded-core + bitbake separately and runs the same parse + fetch checks. The existing kirkstone..walnascar matrix is untouched (still uses poky).

nightly-compile-matrix.yml gains two more kernels: 6.16.12 (whinlatter) and 6.18.29 (wrynose). Matrix is now 8 drivers x 5 kernels = 40 cells.

Follow-up PR will add whinlatter and wrynose release branches with the usual single-release narrowing.