### PR TITLE
Per-kernel driver fixes round 4: kernel 6.16/6.18 green for all 8 drivers

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 # upstream maintainer hasn't picked up.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 PV = "4.3.6.11-git+2026.05"
-SRCREV = "1c03fb14f015482054b5be4efc6d3e39f7f1c944"
+SRCREV = "6b4047755f1a6e4b6caa68b74d71abf699041811"
 SRC_URI = "git://github.com/EmbeddedAndroid/rtl8723bu.git;protocol=https;branch=embeddedandroid \
            file://0002-realtek-Disable-IPS-mode.patch "
 

--- a/recipes-bsp/drivers/rtl8723du.bb
+++ b/recipes-bsp/drivers/rtl8723du.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171d
 # Yocto-specific Makefile glue (modules_install target) and per-kernel
 # compile fixes on top of lwfinger's last upstream commit.
 SRC_URI = "git://github.com/EmbeddedAndroid/rtl8723du;protocol=https;branch=embeddedandroid"
-SRCREV = "750035cadf4de2a1c12fab74f81d757fbfda7598"
+SRCREV = "cc194aed77dad4547c1d8cc28279fb020434e2a6"
 PV = "5.13.4-git+2026.05"
 
 DEPENDS = "virtual/kernel"

--- a/recipes-bsp/drivers/rtl8812au.bb
+++ b/recipes-bsp/drivers/rtl8812au.bb
@@ -6,16 +6,18 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 inherit module
 
 SRC_URI = " \
-    git://github.com/morrownr/8812au-20210820.git;protocol=https;branch=main \
+    git://github.com/EmbeddedAndroid/8812au-20210820.git;protocol=https;branch=embeddedandroid \
     file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 "
 
-# 9704072d is the last good commit before upstream PR #62 (Apr 2026)
-# introduced the same undefined _FW_UNDER_SURVEY reference seen in
-# rtl8821au's PR #198. Includes upstream's kernel 6.13 / 6.14 fixes.
-SRCREV = "9704072df4d75cedf8d622cf2a483aef05109e41"
+# Track an EmbeddedAndroid fork of morrownr/8812au-20210820. The
+# 'embeddedandroid' branch starts from upstream commit 9704072d
+# (Sep 2025) -- the last good revision before upstream PR #62
+# introduced an undefined _FW_UNDER_SURVEY identifier -- and
+# carries kernel 6.16/6.17/6.18 compat patches on top.
+SRCREV = "93079f26e96d61ec0506ba725c333c41f2b155be"
 
-PV = "5.13.6-git+2025.09"
+PV = "5.13.6-git+2026.05"
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE:append = " KSRC=${STAGING_KERNEL_DIR}"

--- a/recipes-bsp/drivers/rtl8821au.bb
+++ b/recipes-bsp/drivers/rtl8821au.bb
@@ -6,15 +6,17 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 inherit module
 
 SRC_URI = " \
-	git://github.com/morrownr/8821au-20210708.git;protocol=https;branch=main \
+	git://github.com/EmbeddedAndroid/8821au-20210708.git;protocol=https;branch=embeddedandroid \
 	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
 "
 
-# 250cdad is the last good commit before upstream PR #198 (Apr 2026)
-# introduced an undefined _FW_UNDER_SURVEY reference. Includes the
-# kernel 6.14 support patch from Apr 2025.
-SRCREV = "250cdad41275444b935f788cabae391b9f4d5bc7"
-PV = "5.12.5.2-git+2025.09"
+# Track an EmbeddedAndroid fork of morrownr/8821au-20210708. The
+# 'embeddedandroid' branch starts from upstream commit 250cdad
+# (Sep 2025) -- the last good revision before upstream PR #198
+# introduced an undefined _FW_UNDER_SURVEY identifier -- and
+# carries kernel 6.16/6.17/6.18 compat patches on top.
+SRCREV = "74af5d63e0b6dffbf111259472844f8f228c6e3b"
+PV = "5.12.5.2-git+2026.05"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/drivers/rtl88x2bu.bb
+++ b/recipes-bsp/drivers/rtl88x2bu.bb
@@ -3,9 +3,12 @@ DESCRIPTION = "RTL88x2BU kernel driver (like RTL8812BU)"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab842b299d0a92fb908d6eb122cd6de9"
 
-SRCREV = "fe48647496798cac77976e310ee95da000b436c9"
+# Track an EmbeddedAndroid fork of morrownr/88x2bu-20210702. The
+# 'embeddedandroid' branch carries kernel 6.16+ compat: timer rename
+# shim and a corrected radio_idx guard (kernel 6.17, not 6.18).
+SRCREV = "42b9a5cd57e8c155b031515042edbf102691a9da"
 SRC_URI = " \
-	git://github.com/morrownr/88x2bu-20210702;protocol=https;branch=main \
+	git://github.com/EmbeddedAndroid/88x2bu-20210702;protocol=https;branch=embeddedandroid \
 	file://0001-fix-makefile.patch \
 "
 PV = "5.13.1-git"


### PR DESCRIPTION
Fourth pass of per-kernel-version maintenance. Closes the kernel 6.16 (whinlatter) and 6.18 (wrynose) gaps surfaced by the nightly compile matrix; the native (driver, kernel) compile matrix is now 40 / 40 green.

Three new EmbeddedAndroid forks were created for drivers where the upstream is either stuck on the legacy compat (rtl8723bu / rtl8723du / 8814au already had forks) or has unfixed regressions in tip-of-branch:

- EmbeddedAndroid/8812au-20210820 (from morrownr 9704072d)
- EmbeddedAndroid/8821au-20210708 (from morrownr 250cdad)
- EmbeddedAndroid/88x2bu-20210702 (from morrownr fe48647)

Shared patch set across all forks for this round:

- Makefile + hal/phydm/phydm.mk: rename EXTRA_CFLAGS to ccflags-y and switch $(src) to $(M) for the include search paths. Kernel 6.16 dropped EXTRA_CFLAGS handling in the external-module build path, so without this the -I/include flags get silently dropped and #include <drv_types.h> + #include "../../hal/phydm/phydm_precomp.h" both stop resolving.
- include/osdep_service_linux.h: kernel 6.16 compat shim mapping del_timer / del_timer_sync / from_timer onto timer_delete / timer_delete_sync / timer_container_of (the old spellings are gone in 6.16).
- core/crypto/sha256.{c,h} + core/crypto/sha256-prf.c (8812au, 8821au) and core/rtw_security.c (rtl8723bu): rename sha256_init / hmac_sha256 / hmac_sha256_vector / hmac_sha256_kdf / sha256_prf / sha256_prf_bits / tls_prf_sha256 with rtw_ prefix. Kernel 6.18 added these symbols to its crypto subsystem; identically-named driver-local exports were colliding.
- os_dep/[linux/]ioctl_cfg80211.c: add int radio_idx parameter to set_wiphy_params / set_tx_power / get_tx_power callbacks on kernel >= 6.17 (88x2bu had a 6.18 guard upstream; corrected to 6.17 where it actually landed).

Native compile matrix at this PR's SRCREVs:

| Driver     | 6.6 | 6.12 | 6.14 | 6.16 | 6.18 |
|------------|-----|------|------|------|------|
| rtl8192eu  | OK  | OK   | OK   | OK   | OK   |
| rtl8723bu  | OK  | OK   | OK   | OK   | OK   |
| rtl8723du  | OK  | OK   | OK   | OK   | OK   |
| rtl8812au  | OK  | OK   | OK   | OK   | OK   |
| rtl8814au  | OK  | OK   | OK   | OK   | OK   |
| rtl8821au  | OK  | OK   | OK   | OK   | OK   |
| rtl8821cu  | OK  | OK   | OK   | OK   | OK   |
| rtl88x2bu  | OK  | OK   | OK   | OK   | OK   |