### PR TITLE
ci: track oe-core/bitbake master for early-warning signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, main]
   pull_request:
   workflow_dispatch:
+  # Daily run picks up oe-core / bitbake master drift even when no
+  # change to this repo has fired CI.
+  schedule:
+    - cron: '37 5 * * *'
 
 # Cancel superseded runs for the same ref to save CI minutes.
 concurrency:
@@ -154,6 +158,78 @@ jobs:
           # oe-core ships oe-init-build-env at its top level; sourcing
           # it without poky's meta-yocto* layers means we only have
           # meta-core, which is what we want for layer-parse smoke.
+          source oe-init-build-env build
+          cat >> conf/local.conf <<'EOF'
+          MACHINE = "qemux86-64"
+          BB_NUMBER_THREADS = "2"
+          PARALLEL_MAKE = "-j 2"
+          INHERIT += "rm_work"
+          CONF_VERSION = "2"
+          EOF
+          bitbake-layers add-layer "$GITHUB_WORKSPACE/meta-rtlwifi"
+          bitbake-layers show-layers
+          bitbake -p
+
+      - name: Fetch all recipes
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+        run: |
+          set -eo pipefail
+          cd oe-core
+          source oe-init-build-env build
+          bitbake -c fetch -k \
+            rtl8192eu rtl8723bu rtl8723du rtl8812au rtl8814au \
+            rtl8821au rtl8821cu rtl88x2bu
+
+  parse-oe-core-master:
+    # Early-warning signal: parse + fetch against oe-core master and
+    # bitbake master. Catches API drift (bitbake CLI, class renames,
+    # new QA checks) before the next Yocto release lands. Marked
+    # continue-on-error so a hot upstream breakage doesn't block
+    # merges to this repo -- the value is the alert, not the gate.
+    name: parse (oe-core master) [informational]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Checkout meta-rtlwifi
+        uses: actions/checkout@v4
+        with:
+          path: meta-rtlwifi
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+                      "$AGENT_TOOLSDIRECTORY"
+
+      - name: Clone oe-core (master)
+        run: |
+          git clone --depth 1 --branch master \
+            https://git.openembedded.org/openembedded-core oe-core
+
+      - name: Clone bitbake (master)
+        run: |
+          git clone --depth 1 --branch master \
+            https://git.openembedded.org/bitbake oe-core/bitbake
+
+      - name: Install Yocto host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gawk wget git diffstat unzip texinfo gcc build-essential chrpath \
+            socat cpio python3 python3-pip python3-pexpect xz-utils debianutils \
+            iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool \
+            file locales libacl1
+          sudo locale-gen en_US.UTF-8
+
+      - name: Parse the layer
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+        run: |
+          set -eo pipefail
+          cd oe-core
           source oe-init-build-env build
           cat >> conf/local.conf <<'EOF'
           MACHINE = "qemux86-64"


### PR DESCRIPTION
Adds a parse-oe-core-master job that clones openembedded-core@master and bitbake@master and runs parse + fetch against them. Marked continue-on-error so a hot upstream breakage doesn't block merges to this repo — the point is the alert, not a gate.

Plus a daily cron at 05:37 UTC so master drift gets caught even when no change to this repo lands for a few days. Offset from the existing nightly-compile-matrix (04:17 UTC) so they don't queue together.

Catches things like bitbake CLI / API changes, class renames, new QA checks in oe-core, layer.conf format changes — all of which today only surface when the next Yocto release lands.